### PR TITLE
Add OpenAI instructions and realtime voice support

### DIFF
--- a/custom-voices.html
+++ b/custom-voices.html
@@ -201,6 +201,61 @@
           </div>
         </div>
       </div>
+      <div class="col-lg-6">
+        <div class="card border-primary openai-realtime">
+          <div class="card-header card-header-dark">
+            OpenAI Realtime
+            <div class="subtext">Use OpenAI's Realtime API for streaming speech</div>
+          </div>
+          <div class="card-body view-new">
+            <div class="form-group">
+              <button type="button" class="btn btn-outline-primary btn-add">Add</button>
+            </div>
+          </div>
+          <div class="card-body view-exist">
+            <div class="form-group">
+              <div class="text-muted">API URL</div>
+              <div class="endpoint-url"></div>
+            </div>
+            <div class="form-group">
+              <div class="text-muted">API Key</div>
+              <div class="api-key"></div>
+            </div>
+            <div class="form-group">
+              <div class="text-muted">Voice List</div>
+              <div class="voice-list"></div>
+            </div>
+            <div class="form-group">
+              <button type="button" class="btn btn-outline-primary btn-edit">Edit</button>
+              <button type="button" class="btn btn-outline-danger btn-delete">Delete</button>
+            </div>
+          </div>
+          <div class="card-body view-edit">
+            <form>
+              <div class="form-group">
+                <label>API URL</label>
+                <input type="text" class="form-control txt-endpoint-url">
+              </div>
+              <div class="form-group">
+                <label>API Key (if required)</label>
+                <input type="password" class="form-control txt-api-key">
+              </div>
+              <div class="form-group">
+                <label>Voice List</label>
+                <textarea class="form-control txt-voice-list" rows="6"></textarea>
+              </div>
+              <div class="form-group">
+                <img class="status progress" src="img/loading.gif">
+                <div class="status error alert alert-danger"></div>
+              </div>
+              <div class="form-group">
+                <button type="button" class="btn btn-primary btn-save">Save</button>
+                <button type="button" class="btn btn-light btn-cancel">Cancel</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </div>
 
   </div>

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -157,6 +157,7 @@ const voices$ = rxjs.combineLatest({
   gcpCreds: observeSetting("gcpCreds"),
   ibmCreds: observeSetting("ibmCreds"),
   openaiCreds: observeSetting("openaiCreds"),
+  openaiRealtimeCreds: observeSetting("openaiRealtimeCreds"),
   azureCreds: observeSetting("azureCreds"),
   piperVoices: observeSetting("piperVoices"),
 }).pipe(
@@ -169,6 +170,7 @@ const voices$ = rxjs.combineLatest({
     settings.ibmCreds ? ibmWatsonTtsEngine.getVoices() : [],
     phoneTtsEngine.getVoices(),
     settings.openaiCreds ? openaiTtsEngine.getVoices() : [],
+    settings.openaiRealtimeCreds ? openaiRealtimeTtsEngine.getVoices() : [],
     settings.azureCreds ? azureTtsEngine.getVoices() : [],
     settings.piperVoices || [],
   ])),
@@ -244,6 +246,10 @@ function isOpenai(voice) {
   return /^OpenAI /.test(voice.voiceName);
 }
 
+function isOpenaiRealtime(voice) {
+  return /^OpenAI Realtime /.test(voice.voiceName);
+}
+
 function isAzure(voice) {
   return /^Azure /.test(voice.voiceName);
 }
@@ -271,6 +277,7 @@ function isNativeVoice(voice) {
     || isGoogleWavenet(voice)
     || isIbmWatson(voice)
     || isOpenai(voice)
+    || isOpenaiRealtime(voice)
     || isAzure(voice)
   )
 }

--- a/js/options.js
+++ b/js/options.js
@@ -299,6 +299,7 @@
         return !voice.lang || selectedLangs.includes(voice.lang.split('-',1)[0])
           || isPiperVoice(voice)
           || isOpenai(voice)
+          || isOpenaiRealtime(voice)
       });
 
     //group by standard/premium

--- a/js/speech.js
+++ b/js/speech.js
@@ -29,6 +29,7 @@ function Speech(texts, options) {
     if (isPiperVoice(options.voice)) return piperTtsEngine;
     if (isAzure(options.voice)) return azureTtsEngine;
     if (isOpenai(options.voice)) return openaiTtsEngine;
+    if (isOpenaiRealtime(options.voice)) return openaiRealtimeTtsEngine;
     if (isUseMyPhone(options.voice)) return phoneTtsEngine;
     if (isGoogleTranslate(options.voice) && !/\s(Hebrew|Telugu)$/.test(options.voice.voiceName)) {
       return googleTranslateTtsEngine


### PR DESCRIPTION
## Summary
- allow OpenAI voices to pass the `instructions` parameter
- add OpenAI Realtime voice engine and configuration form
- default OpenAI voices to Polish `gpt-4o-mini-tts`
- default Realtime voices to Polish `gpt-realtime` and force verbatim playback
- expand default OpenAI voice lists for both TTS and Realtime engines

## Testing
- `npm test` *(fails: command not found: npm; attempted apt install but repository 403)*
- `node --check js/tts-engines.js` *(fails: command not found: node; attempted apt install but repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf69de5558832f85489eac16a42247