### PR TITLE
Apply pitch adjustments for OpenAI voices

### DIFF
--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -979,7 +979,12 @@ function OpenaiTtsEngine() {
         if (prefetchAudio && prefetchAudio[0] == utterance && prefetchAudio[1] == options) return prefetchAudio[2]
         else return getAudioUrl(utterance, options.voice, options.pitch)
       })
-    return playAudio(urlPromise, options, playbackState$)
+    // The OpenAI speech endpoint does not natively support a pitch parameter.
+    // To provide a user‑perceived pitch change we adjust the playback rate
+    // locally.  `rateAdjust` is multiplied against the requested rate in
+    // playAudioHere(), so map the pitch slider (default 1) to this multiplier.
+    const rateAdjust = options.pitch || 1
+    return playAudio(urlPromise, {...options, rateAdjust}, playbackState$)
   }
   this.prefetch = async function(utterance, options) {
     try {


### PR DESCRIPTION
## Summary
- Map pitch slider to playback rate for OpenAI voices to provide audible pitch changes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf6aad351c832fbaf7e2fb76f86a71